### PR TITLE
Update macduff.py

### DIFF
--- a/macduff.py
+++ b/macduff.py
@@ -133,7 +133,7 @@ def draw_colorchecker(colors, centers, image, radius):
     for observed_color, expected_color, pt in zip(colors.reshape(-1, 3),
                                                   expected_colors.reshape(-1, 3),
                                                   centers.reshape(-1, 2)):
-        x, y = pt
+        x, y = pt.astype(int)
         cv.circle(image, (x, y), radius//2, expected_color.tolist(), -1)
         cv.circle(image, (x, y), radius//4, observed_color.tolist(), -1)
     return image


### PR DESCRIPTION
Fixing this error (even the samples won't run without this fix): 

mike@Mikes-MacBook-Pro python-macduff-colorchecker-detector-master % python macduff.py examples/test.jpg result.png > result.csv Traceback (most recent call last):
  File "/Users/mike/Downloads/python-macduff-colorchecker-detector-master/macduff.py", line 525, in <module>
    out, colorchecker = find_macbeth(argv[1])
  File "/Users/mike/Downloads/python-macduff-colorchecker-detector-master/macduff.py", line 491, in find_macbeth
    draw_colorchecker(found_colorchecker.values,
  File "/Users/mike/Downloads/python-macduff-colorchecker-detector-master/macduff.py", line 137, in draw_colorchecker
    cv.circle(image, (x, y), radius//2, expected_color.tolist(), -1)
cv2.error: OpenCV(4.7.0) :-1: error: (-5:Bad argument) in function 'circle'
> Overload resolution failed:
>  - Can't parse 'center'. Sequence item with index 0 has a wrong type
>  - Can't parse 'center'. Sequence item with index 0 has a wrong type